### PR TITLE
Added model fields and their requirements for the ProductTag model/table

### DIFF
--- a/models/ProductTag.js
+++ b/models/ProductTag.js
@@ -1,19 +1,39 @@
-const { Model, DataTypes } = require('sequelize');
+const { Model, DataTypes } = require("sequelize");
 
-const sequelize = require('../config/connection');
+const sequelize = require("../config/connection");
 
 class ProductTag extends Model {}
 
 ProductTag.init(
   {
     // define columns
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    product_id: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: "product",
+        key: "id",
+      },
+    },
+    tag_id: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: "tag",
+        key: "id",
+      },
+    },
   },
   {
     sequelize,
     timestamps: false,
     freezeTableName: true,
     underscored: true,
-    modelName: 'product_tag',
+    modelName: "product_tag",
   }
 );
 


### PR DESCRIPTION
The requirements for the ProductTag model are as below:

**id**
- Integer
- Doesn't allow null values
- Set as primary key
- Uses auto increment

**product_id**
- Integer
- References the product model's id

**tag_id**
- Integer
- References the tag model's id