### PR TITLE
Added parameters to the price's decimal data type to allow precision and scale

### DIFF
--- a/models/Product.js
+++ b/models/Product.js
@@ -21,7 +21,7 @@ Product.init(
       allowNull: false,
     },
     price: {
-      type: DataTypes.DECIMAL,
+      type: DataTypes.DECIMAL(12, 2),
       allowNull: false,
       validate: {
         isDecimal: true,


### PR DESCRIPTION
- The default decimal datatype allows decimal inputs but places the values in the database with a precision of 10 and scale of 0.
- This means that the maximum number of digits that can be stored in the database for the price field is 10, with 0 digits allowed after the decimal point.
- I applied the arguments (12,2) to the data type, meaning a precision of 12 and scale of 2. This will allow up to 12 digits in the price field with 2 being allowed after the decimal point