### PR TITLE
Placed the res return for tags with no associated products inside an else statement

### DIFF
--- a/routes/api/tag-routes.js
+++ b/routes/api/tag-routes.js
@@ -55,9 +55,10 @@ router.post("/", async (req, res) => {
       const productTagData = await ProductTag.bulkCreate(productTagIdArr);
       // send both tagData and productTagData in a single JSON object
       res.status(200).json({ tagData, productTagData });
+    } else {
+      // if there are no associated products for the new tag, just respond with tagData
+      res.status(200).json(tagData);
     }
-    // if there are no associated products for the new tag, just respond with tagData
-    res.status(200).json(tagData);
   } catch (err) {
     res.status(400).json(err);
   }


### PR DESCRIPTION
- The issue was that before the else statement if a tag had associated products then we would try to return 2 response JSON. This caused an error the next time a request was to be made. 
- The error was as follows: `Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client` 
- This error meant that we are trying to set the headers of the HTTP response after they have already been sent to the client (which means we are trying to send a response to the client more than once, which is not allowed)